### PR TITLE
Make compatible with jekyll 2

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,6 +14,9 @@
 		{% if layout.css %}
 		<link rel="stylesheet" href="{{ layout.css | prepend: "/css/" | append: ".css" | prepend: site.baseurl }}" />
 		{% endif %}
+		{% if page.css %}
+		<link rel="stylesheet" href="{{ page.css | prepend: "/css/" | append: ".css" | prepend: site.baseurl }}" />
+		{% endif %}
 		<link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}" />
 		<link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
 	</head>


### PR DESCRIPTION
We use Jekyll 2 in production right now.  Jekyll 2 put frontmatter from
layouts into the `page` global, Jekyll 3 moved it to `layout`.  It makes
sense to allow a page to add custom css as well anyway, so this code
fixed the problem with Jekyll 2 and also adds that feature.